### PR TITLE
Add PerfSink for routing measurements into a host perf system

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,24 @@ PerfCounters.prefix = "myapp.ink."
 
 Set to `""` to drop the prefix entirely.
 
+### Routing measurements into a host perf system
+
+If your app already has its own perf-counter system, install a [`PerfSink`]
+at startup to route every measurement into it — no polling, no enum coupling,
+no separate ring buffer. The host sink only sees label strings, so adding
+or renaming an inksdk metric never breaks the host:
+
+```kotlin
+PerfCounters.sink = PerfSink { label, elapsedNanos ->
+    MyAppCounters.recordByLabel(label, elapsedNanos)
+}
+```
+
+After replacement, `PerfCounters.snapshot()` / `get()` / `reset()` see only
+the (now empty) default ring buffer — your app sink owns snapshotting. The
+default sink remains in place if you don't replace it, so existing consumers
+of `snapshot()` keep working unchanged.
+
 ### Per-controller coverage
 
 `paint.*` and the paint-side `pen.*` metrics rely on a JVM-side "first

--- a/inkcontroller/src/main/java/com/inksdk/ink/PerfCounters.kt
+++ b/inkcontroller/src/main/java/com/inksdk/ink/PerfCounters.kt
@@ -2,8 +2,8 @@ package com.inksdk.ink
 
 /**
  * Performance metrics recorded by the ink pipeline. Each maps to a pre-
- * allocated ring buffer in [PerfCounters] indexed by [ordinal] — no HashMap
- * lookup on the hot path.
+ * allocated ring buffer in [DefaultSink] indexed by [ordinal] — no HashMap
+ * lookup on the hot path when the default sink is in use.
  *
  * Naming follows three tiers by sample rate:
  *  - `pen.*`   — one sample per stroke (perceived first-paint latencies)
@@ -56,38 +56,98 @@ enum class PerfMetric(private val baseName: String) {
 }
 
 /**
+ * Sink for ink-pipeline timing measurements. Each [record] call delivers
+ * one labelled timing sample.
+ *
+ * The default sink ([DefaultSink]) is an in-process ring buffer served by
+ * [PerfCounters.snapshot]/[PerfCounters.get]/[PerfCounters.reset]. Hosts
+ * that already have a perf system can replace [PerfCounters.sink] at startup
+ * to route every measurement into it — no polling, no enum coupling, no
+ * separate ring buffer.
+ *
+ * `metricLabel` is the full [PerfMetric.label] (with [PerfCounters.prefix]
+ * applied), so a host sink can route purely by string and never imports
+ * the [PerfMetric] enum.
+ */
+fun interface PerfSink {
+    fun record(metricLabel: String, elapsedNanos: Long)
+}
+
+/**
  * Zero-allocation hot-path performance counters.
  *
- * Each [PerfMetric] gets a ring buffer of the last [WINDOW_SIZE] timings.
- * [recordDirect] is one synchronized array write — safe to call from any
- * thread (binder thread, UI thread, etc).
- *
- * Percentiles are computed lazily by [snapshot] / [get].
- *
- * Hosts that want to merge these counters into their own perf system can
- * override the [prefix] once at startup (e.g. `PerfCounters.prefix = "myapp.ink."`).
+ * By default routes to [DefaultSink] (a ring-buffer per [PerfMetric] served
+ * by [snapshot]/[get]/[reset]). Replace [sink] at startup to route into a
+ * host perf system instead — after replacement, the polling APIs return
+ * empty results because nothing populates the default ring buffer.
  */
 object PerfCounters {
-
-    private const val WINDOW_SIZE = 200
 
     /** Prefix prepended to every [PerfMetric.label]. Defaults to `"ink."`.
      *  Set once at startup; not safe to mutate while metrics are being read. */
     @Volatile var prefix: String = "ink."
 
-    @PublishedApi
-    internal val counters = Array(PerfMetric.entries.size) { RingCounter(WINDOW_SIZE) }
+    /** Where every measurement goes. Defaults to [DefaultSink]; hosts can
+     *  replace at startup to route into their own perf system. After
+     *  replacement, [snapshot]/[get]/[reset] become no-op-ish (they only
+     *  see the default ring buffer, which no longer receives writes). */
+    @Volatile var sink: PerfSink = DefaultSink
 
     /** Time a block and record the elapsed nanos. Returns the block result. */
     inline fun <T> time(metric: PerfMetric, block: () -> T): T {
-        val start = System.nanoTime()
-        val result = block()
-        counters[metric.ordinal].record(System.nanoTime() - start)
-        return result
+        val t0 = System.nanoTime()
+        return try {
+            block()
+        } finally {
+            recordDirect(metric, System.nanoTime() - t0)
+        }
     }
 
     /** Record an externally-measured nanos value (e.g. cross-clock latency). */
     fun recordDirect(metric: PerfMetric, elapsedNanos: Long) {
+        // Fast path: when the default sink is installed, skip the label
+        // round-trip and write to the ordinal-indexed ring directly.
+        val s = sink
+        if (s === DefaultSink) {
+            DefaultSink.recordTyped(metric, elapsedNanos)
+        } else {
+            s.record(metric.label, elapsedNanos)
+        }
+    }
+
+    fun get(metric: PerfMetric): CounterSnapshot = DefaultSink.get(metric)
+
+    fun snapshot(): Map<PerfMetric, CounterSnapshot> = DefaultSink.snapshot()
+
+    fun reset() = DefaultSink.reset()
+}
+
+/**
+ * Default sink — an ordinal-indexed ring buffer per [PerfMetric].
+ *
+ * Hosts that don't replace [PerfCounters.sink] consume it via
+ * [PerfCounters.snapshot]/[PerfCounters.get]/[PerfCounters.reset]. Hosts
+ * that *do* install a custom sink leave this object empty.
+ */
+object DefaultSink : PerfSink {
+
+    private const val WINDOW_SIZE = 200
+
+    private val counters = Array(PerfMetric.entries.size) { RingCounter(WINDOW_SIZE) }
+
+    private val labelToMetric: Map<String, PerfMetric> by lazy {
+        PerfMetric.entries.associateBy { it.label }
+    }
+
+    /** [PerfSink] entry point — a host that installs another sink AND
+     *  also calls back into [DefaultSink.record] (for tests, mostly) ends
+     *  up here; we resolve the label back to a [PerfMetric] if known. */
+    override fun record(metricLabel: String, elapsedNanos: Long) {
+        labelToMetric[metricLabel]?.let { counters[it.ordinal].record(elapsedNanos) }
+    }
+
+    /** Hot path for the in-process default route. Skips the string lookup. */
+    internal fun recordTyped(metric: PerfMetric, elapsedNanos: Long) {
         counters[metric.ordinal].record(elapsedNanos)
     }
 

--- a/inkcontroller/src/test/java/com/inksdk/ink/PerfCountersTest.kt
+++ b/inkcontroller/src/test/java/com/inksdk/ink/PerfCountersTest.kt
@@ -9,6 +9,7 @@ class PerfCountersTest {
 
     @After
     fun tearDown() {
+        PerfCounters.sink = DefaultSink
         PerfCounters.reset()
         PerfCounters.prefix = "ink."
     }
@@ -80,6 +81,51 @@ class PerfCountersTest {
         // Empty prefix is honoured (no namespace at all).
         PerfCounters.prefix = ""
         assertEquals("pen.kernel_to_paint", PerfMetric.PEN_KERNEL_TO_PAINT.label)
+    }
+
+    @Test
+    fun installedSinkReceivesRecordingsWithFullLabels() {
+        val received = mutableListOf<Pair<String, Long>>()
+        PerfCounters.sink = PerfSink { label, nanos -> received += label to nanos }
+
+        PerfCounters.recordDirect(PerfMetric.PEN_KERNEL_TO_PAINT, 5_000_000L)
+        PerfCounters.time(PerfMetric.EVENT_HANDLER) { /* no-op */ }
+
+        assertEquals(2, received.size)
+        assertEquals("ink.pen.kernel_to_paint", received[0].first)
+        assertEquals(5_000_000L, received[0].second)
+        assertEquals("ink.event.handler", received[1].first)
+        assertTrue("non-negative elapsed", received[1].second >= 0L)
+    }
+
+    @Test
+    fun installedSinkReceivesPrefixedLabels() {
+        PerfCounters.prefix = "myapp.ink."
+        val received = mutableListOf<String>()
+        PerfCounters.sink = PerfSink { label, _ -> received += label }
+
+        PerfCounters.recordDirect(PerfMetric.PAINT_DRAW_SEGMENT, 1_000L)
+        assertEquals("myapp.ink.paint.draw_segment", received.single())
+    }
+
+    @Test
+    fun pollingApisReturnEmptyAfterSinkReplaced() {
+        // After installing a custom sink, the default ring buffer never sees
+        // recordings — snapshot/get/reset operate against the default sink
+        // and so report empty. This is the documented contract: a host that
+        // takes ownership of recording also owns its own snapshot.
+        PerfCounters.sink = PerfSink { _, _ -> /* swallow */ }
+        PerfCounters.recordDirect(PerfMetric.PEN_KERNEL_TO_PAINT, 5_000_000L)
+
+        assertEquals(0L, PerfCounters.get(PerfMetric.PEN_KERNEL_TO_PAINT).count)
+        assertTrue(PerfCounters.snapshot().values.all { it.count == 0L })
+    }
+
+    @Test
+    fun defaultSinkIsBackwardCompatible() {
+        // No sink replacement — the existing API contract holds.
+        PerfCounters.recordDirect(PerfMetric.PEN_KERNEL_TO_PAINT, 5_000_000L)
+        assertEquals(1L, PerfCounters.get(PerfMetric.PEN_KERNEL_TO_PAINT).count)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds `fun interface PerfSink { fun record(label: String, elapsedNanos: Long) }` and refactors `PerfCounters` to delegate to a swappable `sink`. The default sink (now extracted as `DefaultSink`) preserves the existing ring-buffer behavior — `snapshot()` / `get()` / `reset()` work exactly as before when nothing overrides the sink, so this is fully backward-compatible.

Hosts that already have their own perf system can replace `PerfCounters.sink` at startup and route every measurement as a label+nanos pair. No polling, no `PerfMetric`-enum coupling, no duplicated ring buffer. Renaming or adding a metric in inksdk no longer risks breaking the host because the sink contract is purely string-keyed.

Hot path for the default sink stays zero-allocation: `recordDirect` identity-checks the sink and skips the label round-trip when `DefaultSink` is in use.

## Motivation

Integrating inksdk into a host app (mokke) that has its own `PerfCounters` / `CounterSnapshot` infrastructure. Without `PerfSink`, the host has to poll inksdk on a separate code path and adapt structurally-identical data classes across packages — a bridge that becomes redundant once `PerfSink` lands.

## Test plan

- [x] Existing `PerfCountersTest` still passes (8 tests)
- [x] New tests cover sink replacement, prefixed labels delivered to sinks, polling APIs returning empty after sink replacement, and default-sink backward compat (4 tests, 12 total)
- [x] `./gradlew :inkcontroller:testDebugUnitTest` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)